### PR TITLE
GEXF conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Release history
   to learn associations from cue vectors to target vectors
   in a one-shot fashion without catastrophic forgetting.
   (`#72 <https://github.com/nengo/nengo-extras/pull/72>`_)
+- Added classes to convert Nengo models to GEXF for visualization with Gephi.
+  (`#54 <https://github.com/nengo/nengo-extras/pull/54>`_)
 
 0.1.0 (March 14, 2018)
 ======================

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -14,3 +14,7 @@ code, .rst-content tt, .rst-content code {
     padding-left: 0;
     width: inherit;
 }
+
+.body img {
+    max-width: 100%;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,6 @@ extensions = [
     'sphinx.ext.viewcode',
     'guzzle_sphinx_theme',
     'numpydoc',
-    'nengo.utils.docutils',
     'nbsphinx',
     'nbsphinx_link',
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,8 @@ extensions = [
     'nbsphinx_link',
 ]
 
+default_role = 'py:obj'
+
 # -- sphinx.ext.autodoc
 autoclass_content = 'both'  # class and __init__ docstrings are concatenated
 autodoc_default_flags = ['members']

--- a/docs/gephi-tutorial.rst
+++ b/docs/gephi-tutorial.rst
@@ -1,0 +1,299 @@
+*************************************
+Visualizing Nengo networks with Gephi
+*************************************
+
+`Gephi <https://gephi.org/>`_ is an open-source graph visualization and
+exploration program. It can be useful to analyze larger scale Nengo networks as
+it gives some more flexibility with the representation than Nengo GUI currently
+provides. The following will give a step-by-step introduction how to export
+a Nengo model, import it in Gephi and produce a basic visualization. For
+a deeper introduction into Gephi, you might want to take a look at `general
+Gephi tutorials <https://gephi.org/users/>`_.
+
+Step 1: Exporting a Nengo model to GEXF
+=======================================
+
+To load the graph of a Nengo model in Gephi, it first needs to be exported into
+the GEXF format. That is an XML-based description of the graph that can be
+opened with Gephi.
+
+For this tutorial, we will use the model presented by [1]_ which is available
+from `GitHub <https://github.com/ctn-archive/kajic-cogsci2017>`_. To install
+the model:
+
+.. code-block:: bash
+
+   git clone https://github.com/ctn-archive/kajic-cogsci2017.git
+   cd kajic-cogsci2017
+   pip install -r requirements.txt
+   python setup.py develop
+   cd scripts
+   python fetch_external.py
+   python categorize_animals.py
+   cd ../cogsci17-semflu
+   python create_database.py
+   cd ..
+
+To convert the model to GEXF only a few lines of Python code are required::
+
+    from cogsci17_semflu.models.wta_semflu import SemFlu
+    from nengo_extras.gexf import CollapsingGexfConverter
+
+    model = SemFlu().make_model(d=256, seed=12)  # This creates the model
+    # The next line exports the model to semflu.gexf.
+    CollapsingGexfConverter().convert(model).write('semflu.gexf')
+
+The `.CollapsingGexfConverter` will collapse the following networks into
+a single graph node because the details of those networks are often not of
+interest:
+
+* ``nengo.networks.CircularConvolution``
+* ``nengo.networks.EnsembleArray``
+* ``nengo.networks.Product``
+* Networks from `Nengo SPA <https://github.com/nengo/nengo-spa>`_ (but not
+  ``nengo.spa``!)
+
+The *to_collapse* constructor argument allows to specify a custom list of
+networks to collapse. To not collapse any networks, the `.GexfConverter` class
+can be used too.
+
+.. note::
+
+   The export will flatten all networks by default. To keep the network
+   hierarchy you can pass ``hierarchical=True`` to `.GexfConverter` or
+   `.CollapsingGexfConverter`. However, support for hierarchical graphs was
+   removed in Gephi 0.9. The containing nodes of a hierarchical graph will
+   be added as unconnected nodes to the graph which is not helpful. If you want
+   the hierarchy to visualized, you can try an older Gephi version, but expect
+   that you will also need to install an outdated Java version which might
+   require you to create a (free) account with Oracle.
+
+Step 2: Loading the GEXF file in Gephi
+======================================
+
+The GEXF file can be opened via the *File > Open* menu. After choosing the
+file, an import dialog will be shown. For many Nengo networks it is best to
+click *More Options* and select “First” for the *Edges merge strategy*.
+With “Sum”, the scaling of the thickness of connections and their arrowheads
+might be problematic. This is because it is common to have only a single
+connection between two components (which would get a weight of 1), but it is
+also common to have a large number of connections between two components when
+networks got collapsed (the connections do not get collapsed) which would sum
+up to a very large weight.
+
+.. image:: https://i.imgur.com/bqpxc3N.png
+   :alt: The Gephi import window.
+
+Overview of the Gephi interface
+-------------------------------
+
+The central part of the Gephi window shows the current graph visualization. For
+a freshly loaded GEXF file, all the nodes will be randomly placed and
+everything is in black. We will improve on that state shortly, but first take
+a look of the general organization of the user interface. You can zoom the
+visualization with the scroll wheel on your mouse. To move the view click and
+drag with the right mouse button.
+
+The toolbar to the left of the visualization provides mostly editing tools to
+edit the graph or its appearance. The bottom toolbar gives tools to influence
+how things are displayed.
+
+The remaining parts of the window are organized in a somewhat logical flow. We
+will start at in the top left (1) to make some initial adjustments to the graph
+appearance based on different network attributes. Then will will use the layout
+section below it (2) to obtain a first pass layout to start sorting things out.
+Finally, the right panel allows us to select or filter out parts of the graph
+based on network attributes.
+
+.. image:: https://i.imgur.com/bt9BdS8.png
+   :alt: The Gephi main view.
+   :target: https://i.imgur.com/bt9BdS8.png
+
+Step 3: Setting up the appearance
+=================================
+
+Let us start by introducing some color into the network graph. To get a better
+idea what nodes belong together it can be helpful to color them by the network
+they belong to. Select *Nodes* in the *Appearance* box (top left). On the right
+side you can choose which aspect of the appearance should be changed. Select
+the color palette symbol to change node colors. In the row below select
+*Partition* and choose *net_label* from the drop-down menu. This will give you
+a list of all network names with color predefined for the most common ones. If
+you want, you can edit the assigned colors. When you are satisfied with the
+choices click the *Apply* button in the lower right to apply your choices.
+
+.. image:: https://i.imgur.com/FRtT1Xw.png
+   :alt: Coloring nodes by network name.
+
+Next, let us visualize the number of neurons in each ensemble (or collapsed
+network) by the size of the node. Select symbol with the three differently
+sized circles in upper right and select *Ranking* in the row below. In the
+drop-down choose *n_neurons*. You can play with the minimum and maximum size
+settings. A good starting point is 10 and 40. In the lower left is a *Spline*
+link that allows you to specify how exactly the neuron number should be mapped
+onto size. Again, the settings are applied by clicking the *Apply* button in
+the lower right.
+
+.. image:: https://i.imgur.com/ZMe7ZcV.png
+   :alt: Changing node size by neuron number.
+
+Finally, let us visualize the type of connections. Select *Edges* in the upper
+left and the color palette symbol on the right. Then choose *Partition* and
+*post_type* in the drop down menu. The *post_type* attribute give the type of
+the object that is target by a connection. There is also a *pre_type* attribute
+that gives the type of the object a connection originates from. In this case
+the default color choices are not extremely helpful. Connections that target
+ensembles or nodes are normal connections, so we want those to be black. To set
+the color, press the left mouse button and drag the cursor to the desired color
+in the pop up. To get more control over the color selection, right click the
+square (you might need to left click it first) which opens a modal with
+different color pickers. A connections to neurons is likely to be inhibitory,
+so let us set that color to red. Once finished setting the colors, click
+*Apply* as usual.
+
+.. image:: https://i.imgur.com/6CqzQYV.png
+   :alt: Coloring connections by type.
+
+With all these appearance settings applied, the graph should look something
+like this:
+
+.. image:: https://i.imgur.com/heLNPJF.png
+   :alt: The graph after setting up the appearance.
+
+You might want to know what the different nodes are. You can display node labels
+by toggling the black T icon in the bottom toolbar. Then adjust the label size
+with the right slider until you got a good balance between too much clutter and
+legible font size.
+
+.. image:: https://i.imgur.com/fuxf8kb.png
+   :alt: Display toolbar.
+
+The other slider adjusts the thickness of connections which might also be
+useful.
+
+Step 4: Improving the layout
+============================
+
+So far it is still hard to make sense of the graph because everything is
+positioned randomly. Now we are going to improve on that state. The lower left
+layout pane provides a number of graph layout algorithms. Select *Force Atlas*
+from the drop-down menu. It tends to give a decent initial layout, but feel
+free to try other layout algorithms or parameter settings. For now the default
+parameters should be fine. When you click *Run*, you can watch the algorithm do
+its work.
+
+.. image:: https://i.imgur.com/l4gFqSI.png
+   :alt: The layout pane.
+
+Once you are satisfied with the result, stop the algorithm by clicking the
+*Stop* button that the *Run* button turned into. The graph should look
+something like this now:
+
+.. image:: https://i.imgur.com/zVuqOau.png
+   :alt: The graph after running the Force Atlas layout algorithm.
+
+Further improvements can be made by hand with the move tool. It is the hand
+icon in the vertical toolbar left of the main view. It will affect all nodes
+with a certain radius of the cursor. That radius can be adjusted by clicking
+the *Configure* link at the top. That allows you to not just move individual
+nodes at once, but whole clusters by setting an appropriate radius.
+
+.. image:: https://i.imgur.com/Oq4kbhk.png
+   :alt: The move tool.
+
+With a little bit of work, your graph might look like this:
+
+.. image:: https://i.imgur.com/KV9tnTl.png
+   :alt: The graph after manually improving the layout.
+
+Step 5: Merging nodes
+=====================
+
+You might notice the big green and pale violet clusters. These are associative
+memory networks and showing all the detail might not be particularly useful. We
+could have used the `.CollapsingGexfConverter` to merge all of these nodes into
+a single node, but we can also do this after the fact. First activate the select
+tool.
+
+.. image:: https://i.imgur.com/k2A2lhe.png
+   :alt: The selection tool.
+
+Then drag a box around one of those clusters to select all the nodes in it and
+access the context menu with a right click. In that menu click *Select in data
+laboratory*.
+
+.. image:: https://i.imgur.com/CixEY30.png
+   :alt: The context menu allows to select entries in the Data Laboratory.
+
+Next switch to the *Data Laboratory* with the button right under the menu bar.
+
+.. image:: https://i.imgur.com/ObReneJ.png
+   :alt: The view selection.
+
+In the Data Laboratory open the context menu by right clicking on one of the
+selected nodes and choose *Merge nodes*.
+
+.. image:: https://i.imgur.com/M2IXM0G.png
+   :alt: The Data Laboratory context menu allows to merge nodes.
+
+This will open a dialog that allows you to configure how to merge the nodes.
+Make your choices and confirm the merge. Then go back to the *Overview* by
+clicking the button directly under the menu bar. You should now see a single
+node for the selected set of nodes:
+
+.. image:: https://i.imgur.com/VAAIDth.png
+   :alt: The graph after merging the nodes of the associative networks.
+
+Step 6: Selecting and filtering
+===============================
+
+We now have a visualization of the model that allows us to easily get an
+overview of the structure and follow individual connections which can be
+extremely useful when debugging large-scale networks. Sometimes such tasks are
+even easier when selectively displaying certain parts of the network based on
+certain properties.
+
+This can be achieved with the filtering pane on the right. The top part
+provides different filters and operators that can be combined to complex
+queries by dragging the into the lower part of the pane.
+
+For example, we might be interested in all nodes that provide external input or
+in other words all nodes that do not get any input. To find these nodes the
+*In-Degree Range* filter in *Topology* can be used. Drag it to the query
+window, select it and use the slider at the bottom to configure it to consider
+only nodes with an in-degree of 0.
+
+When you click *Select*, the filter will select all nodes that do not receive
+any input.
+
+.. image:: https://i.imgur.com/aBoh2vg.png
+   :alt: Using a query to select things.
+   :target: https://i.imgur.com/aBoh2vg.png
+
+This can be useful to apply manipulations or move a group of nodes that is not
+spatially clustered.
+
+If you toggle *Filter* instead, everything else in the network will be
+completely hidden.
+
+.. image:: https://i.imgur.com/CixEY30.png
+   :alt: Using a query to filter the graph.
+   :target: https://i.imgur.com/CixEY30.png
+
+This should be sufficient to get you started on using Gephi to analyze and
+debug your models. Of course, there are many more Gephi features that have not
+been covered here and can be useful for certain tasks. While Gephi gives you
+some more freedom and more features than Nengo GUI, it is certainly not
+a complete replacement, but rather an additional tool that might be better
+suited for certain tasks and less suited for other tasks. The major downside of
+Gephi is that a change to your model requires you to export the network again
+and redo the network layout in Gephi.
+
+References
+==========
+
+.. [1] Ivana Kajić, Jan Gosmann, Brent Komer, Ryan W. Orr, Terrence C. Stewart,
+   and Chris Eliasmith. A biologically constrained model of semantic memory
+   search. In Proceedings of the 39th Annual Conference of the Cognitive
+   Science Society.  London, UK, 2017. Cognitive Science Society. URL:
+   http://mindmodeling.org/cogsci2017/papers/0127/index.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,7 @@ To install Nengo extras, we recommend using ``pip``.
    vision-examples
    visualization
    visualization-examples
+   gephi-tutorial
 
 * :ref:`genindex`
 

--- a/docs/visualization.rst
+++ b/docs/visualization.rst
@@ -91,3 +91,21 @@ TkInter GUIs
 .. autoclass:: nengo_extras.deepview.VerticalImageFrame
 
 .. autoclass:: nengo_extras.deepview.Viewer
+
+Gephi visualization
+===================
+
+.. autosummary::
+
+   nengo_extras.gexf.DispatchTable
+   nengo_extras.gexf.HierarchicalLabeler
+   nengo_extras.gexf.GexfConverter
+   nengo_extras.gexf.CollapsingGexfConverter
+
+.. autoclass:: nengo_extras.gexf.DispatchTable
+
+.. autoclass:: nengo_extras.gexf.HierarchicalLabeler
+
+.. autoclass:: nengo_extras.gexf.GexfConverter
+
+.. autoclass:: nengo_extras.gexf.CollapsingGexfConverter

--- a/nengo_extras/gexf.py
+++ b/nengo_extras/gexf.py
@@ -1,9 +1,12 @@
 """Export to GEXF for visualization of networks in Gephi."""
 
-from collections import Mapping, Sequence
+from collections import Mapping, namedtuple, OrderedDict, Sequence
+from datetime import date
 import weakref
+import xml.etree.ElementTree as et
 
 import nengo
+import numpy as np
 
 
 class DispatchTable(object):
@@ -170,3 +173,323 @@ class HierarchicalLabeler(object):
         self._names = weakref.WeakKeyDictionary()
         self.dispatch(model)
         return self._names
+
+
+Attr = namedtuple('Attr', ['id', 'type', 'default'])
+
+
+class GexfConverter(object):
+    """Converts Nengo models into GEXF files.
+
+    This can be loaded in Gephi for visualization of the model graph.
+
+    Links:
+
+    * `Gephi <https://gephi.org/>`_
+    * `GEXF <https://github.com/gephi/gexf/wiki>`_
+
+    This class can be inherited from to customize the conversion or
+    alternatively the `dispatch` table can be changed on a per-instance basis.
+
+    Note that probes are currently not included in the graph.
+
+    The following attributes will be stored on graph nodes:
+
+    * *type*: type of the Nengo object (e.g., *nengo.ensemble.Ensemble*),
+    * *net*: unique ID of the containing network,
+    * *net_label*: (possibly non-unique) label of the containing network,
+    * *size_in*: input size,
+    * *size_out*: output_size,
+    * *radius*: ensemble radius (unset for other nodes),
+    * *n_neurons*: number of neurons (0 for non-ensembles),
+    * *neuron_type*: string representation of the neuron type (unset for
+      non-ensembles).
+
+    The following attributes will be stored on graph edges:
+
+    * *pre_type*: type of the connection's pre object (e.g.,
+      *nengo.ensemble.Neurons*),
+    * *post_type*: type of the connection's post object (e.g.,
+      *nengo.ensemble.Neurons*),
+    * *synapse*: string representation of the synapse,
+    * *tau*: the tau parameter of the synapse if existent,
+    * *function*: string representation of the connection's function,
+    * *transform*: string representation of the connection's transform,
+    * *scalar_transform*: float representation of the transform if it is a
+      scalar,
+    * *learning_rule_type*: string representation of the connection's learning
+      rule type.
+
+    Parameters
+    ----------
+    labeler : optional
+        Object with a `get_labels` method that returns a dictionary mapping
+        model objects to labels. If not given, a new `HierarchicalLabeler`
+        will be used.
+    hierarchical : bool, optional (default: False)
+        Whether to include information of the network hierarchy in the file.
+        Support for hierarchical graphs was removed in Gephi 0.9 and
+        hierarchical networks will be automatically flattened which leaves an
+        unconnected node for every network.
+
+    Examples
+    --------
+
+    Basic usage to write a GEXF file::
+
+        GexfConverter().convert(model).write('model.gexf')
+    """
+
+    dispatch = DispatchTable()
+
+    node_attrs = OrderedDict((
+        ('type', Attr(0, 'string', None)),
+        ('net', Attr(1, 'long', None)),
+        ('net_label', Attr(2, 'string', None)),
+        ('size_in', Attr(3, 'integer', None)),
+        ('size_out', Attr(4, 'integer', None)),
+        ('radius', Attr(5, 'float', None)),
+        ('n_neurons', Attr(6, 'integer', 0)),
+        ('neuron_type', Attr(7, 'string', None)),
+        ))
+    edge_attrs = OrderedDict((
+        ('pre_type', Attr(0, 'string', None)),
+        ('post_type', Attr(1, 'string', None)),
+        ('synapse', Attr(2, 'string', None)),
+        ('tau', Attr(3, 'float', None)),
+        ('function', Attr(4, 'string', None)),
+        ('transform', Attr(5, 'string', None)),
+        ('scalar_transform', Attr(6, 'float', 1.)),
+        ('learning_rule_type', Attr(7, 'string', None)),
+    ))
+
+    def __init__(self, labeler=None, hierarchical=False):
+        if labeler is None:
+            labeler = HierarchicalLabeler()
+        self.labeler = labeler
+        self.hierarchical = hierarchical
+        self.version = (1, 3)
+        self.tag = 'draft'
+
+        # State used during processing of a model
+        # WeakKeyDict so we don't prevent garbage collection after conversion
+        # finished.
+        self._labels = weakref.WeakKeyDictionary()
+        self._net = None
+
+    def convert(self, model):
+        """Convert a model to GEXF format.
+
+        Returns
+        -------
+        xml.etree.ElementTree.ElementTree
+            Converted model.
+        """
+        self._labels = self.labeler.get_labels(model)
+        self._labels[model] = 'model'
+        return self.make_document(model)
+
+    def make_document(self, model):
+        """Create the GEXF XML document from *model*.
+
+        This method is exposed so it can be overwritten in inheriting classes.
+        Invoke `convert` instead of this method to convert a model.
+
+        Returns
+        -------
+        xml.etree.ElementTree.ElementTree
+            Converted model.
+        """
+        version = '.'.join(str(i) for i in self.version)
+        tag_version = version + self.tag
+        gexf = et.Element('gexf', {
+            'xmlns': 'http://www.gexf.net/' + tag_version,
+            'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+            'xsi:schemaLocation': (
+                'http://www.gexf.net/' + tag_version + ' ' +
+                'http://www.gexf.net/' + tag_version + '/gexf.xsd'),
+            'version': version
+        })
+
+        meta = et.SubElement(gexf, 'meta', {
+            'lastmodifieddate': date.today().isoformat()})
+        creator = et.SubElement(meta, 'creator')
+        creator.text = self.get_typename(self)
+
+        graph = et.SubElement(gexf, 'graph', {'defaultedgetype': 'directed'})
+        graph.append(self.make_attr_defs('node', self.node_attrs))
+        graph.append(self.make_attr_defs('edge', self.edge_attrs))
+
+        graph.append(self.dispatch(model))
+
+        edges = et.SubElement(graph, 'edges')
+        edges.extend([self.dispatch(c) for c in model.all_connections])
+
+        return et.ElementTree(gexf)
+
+    def make_attr_defs(self, cls, defs):
+        """Generate an attribute definition block.
+
+        Parameters
+        ----------
+        cls : str
+            Class the attribute definitions are for ('node' or 'edge').
+        defs : dict
+            Attribute definitions. Maps attribute names to `Attr` instances.
+
+        Returns
+        -------
+        xml.etree.ElementTree.Element
+        """
+        attributes = et.Element('attributes', {'class': cls})
+        for k, d in defs.items():
+            attr = et.SubElement(attributes, 'attribute', {
+                'id': str(d.id),
+                'title': k,
+                'type': d.type,
+            })
+            if d.default is not None:
+                default = et.SubElement(attr, 'default')
+                default.text = str(d.default)
+        return attributes
+
+    def make_attrs(self, defs, attrs):
+        """Generates a block of attribute values.
+
+        Parameters
+        ----------
+        defs : dict
+            Attribute definitions. Maps attribute names to `Attr` instances.
+        attrs : dict
+            Mapping of attribute names to assigned values.
+
+        Returns
+        -------
+        xml.etree.ElementTree.Element
+        """
+        values = et.Element('attvalues')
+        assert all(k in defs for k in attrs.keys())
+        for k, d in defs.items():
+            if k in attrs and attrs[k] is not None:
+                values.append(et.Element('attvalue', {
+                    'for': str(d.id),
+                    'value': str(attrs[k]),
+                }))
+        return values
+
+    def make_node(self, obj, **attrs):
+        """Generate a node for *obj* with attributes *attrs*."""
+        tag_attrib = {'id': str(id(obj))}
+        if obj in self._labels:
+            tag_attrib['label'] = self._labels[obj]
+        node = et.Element('node', tag_attrib)
+        if len(attrs) > 0:
+            node.append(self.make_attrs(self.node_attrs, attrs))
+        return node
+
+    def make_edge(self, obj, source, target, **attrs):
+        "Edge for *obj* from *source* to *target* with attributes *attrs*."
+        tag_attrib = {
+            'id': str(id(obj)),
+            'source': str(id(source)),
+            'target': str(id(target))
+        }
+        edge = et.Element('edge', tag_attrib)
+        if len(attrs) > 0:
+            edge.append(self.make_attrs(self.edge_attrs, attrs))
+        return edge
+
+    @dispatch.register(nengo.Network)
+    def convert_network(self, net):
+        parent_net = self._net
+        self._net = net
+
+        nodes = et.Element('nodes')
+        leaves = net.ensembles + net.nodes + net.probes
+        for leave in leaves:
+            leave_elem = self.dispatch(leave)
+            if leave_elem is not None:
+                nodes.append(leave_elem)
+        if self.hierarchical:
+            for subnet in net.networks:
+                subnet_node = self.make_node(
+                    subnet, type=self.get_typename(subnet), net=id(self._net),
+                    net_label=self._labels.get(self._net, None),
+                    n_neurons=subnet.n_neurons)
+                subnet_node.append(self.dispatch(subnet))
+                nodes.append(subnet_node)
+        else:
+            for subnet in net.networks:
+                nodes.extend(self.dispatch(subnet))
+
+        self._net = parent_net
+        return nodes
+
+    @dispatch.register(nengo.Ensemble)
+    def convert_ensemble(self, ens):
+        return self.make_node(
+            ens,
+            type=self.get_typename(ens),
+            net=id(self._net),
+            net_label=self._labels.get(self._net, None),
+            size_in=ens.dimensions,
+            size_out=ens.dimensions,
+            radius=ens.radius,
+            n_neurons=ens.n_neurons,
+            neuron_type=ens.neuron_type,
+        )
+
+    @dispatch.register(nengo.Node)
+    def convert_node(self, node):
+        return self.make_node(
+            node,
+            type=self.get_typename(node),
+            net=id(self._net),
+            net_label=self._labels.get(self._net, None),
+            size_in=node.size_in,
+            size_out=node.size_out,
+        )
+
+    @dispatch.register(nengo.Probe)
+    def convert_probe(self, probe):
+        return None
+
+    @dispatch.register(nengo.Connection)
+    def convert_connection(self, conn):
+        source = self.get_node_obj(conn.pre_obj)
+        target = self.get_node_obj(conn.post_obj)
+        return self.make_edge(
+            conn, source, target,
+            pre_type=self.get_typename(conn.pre_obj),
+            post_type=self.get_typename(conn.post_obj),
+            synapse=conn.synapse,
+            tau=conn.synapse.tau if hasattr(conn.synapse, 'tau') else None,
+            function=conn.function,
+            transform=conn.transform,
+            scalar_transform=(
+                conn.transform if np.isscalar(conn.transform) else None),
+            learning_rule_type=conn.learning_rule_type
+        )
+
+    def get_node_obj(self, obj):
+        """Get an object with a corresponding graph node related to *obj*.
+
+        For certain objects like `nengo.ensemble.Neurons` or
+        `nengo.connection.LearningRule` no graph node will be created. This
+        function will resolve such an object to a related object that has a
+        corresponding graph node (e.g., the ensemble for a neurons object or
+        the pre object for a learning rule).
+
+        In `GexfConverter` this is used to make sure connections are between
+        the correct nodes and do not introduce unrelated dangling nodes.
+        """
+        if isinstance(obj, nengo.ensemble.Neurons):
+            return obj.ensemble
+        elif isinstance(obj, nengo.connection.LearningRule):
+            return self.get_node_obj(obj.connection.pre_obj)
+        return obj
+
+    @classmethod
+    def get_typename(cls, obj):
+        tp = type(obj)
+        return tp.__module__ + '.' + tp.__name__

--- a/nengo_extras/gexf.py
+++ b/nengo_extras/gexf.py
@@ -1,0 +1,96 @@
+"""Export to GEXF for visualization of networks in Gephi."""
+
+import weakref
+
+
+class DispatchTable(object):
+    """A descriptor to dispatch to other methods depending on argument type.
+
+    How to use: assign the descriptor to a class attribute and use the
+    `register` decorator to declare which functions to dispatch to for specific
+    types::
+
+        class MyClass(object):
+            dispatch = DispatchTable()
+
+            @dispatch.register(TypeA)
+            def handle_type_a(self, obj_of_type_a):
+                # ...
+
+            @dispatch.register(TypeB)
+            def handle_type_b(self, obj_of_type_b):
+                # ...
+
+    To then call the method for the appropriate type::
+
+        inst = MyClass()
+        inst.dispatch(obj_of_type_a_or_b)
+
+    If multiple methods would match (e.g. if *TypeB* inherits from *TypeA*),
+    the most specific method will be used (to be precise: the first type in the
+    method resolution order with a registered method will be used).
+
+    The *DispatchTable* descriptor accepts another *DispatchTable* as argument
+    which will be used as a fallback. This allows to inherit the dispatch
+    table and selectively overwrite methods like so::
+
+        class Inherited(MyClass):
+            dispatch = DispatchTable(MyClass.dispatch)
+
+            @dispatch.register(TypeA)
+            def alternate_type_a_handler(self, obj_of_type_a):
+                # ...
+
+    Finally, dispatch methods can also be changed on a per-instance basis::
+
+        inst.dispatch.register(TypeA, inst_type_a_handler)
+    """
+
+    class InstDispatch(object):
+        """Return value when accessing the dispatch table on an instance."""
+        __slots__ = ('param', 'inst', 'owner')
+
+        def __init__(self, param, inst, owner):
+            self.param = param
+            self.inst = inst
+            self.owner = owner
+
+        def __call__(self, obj):
+            for cls in obj.__class__.__mro__:
+                if cls in self.param.inst_type_table.get(self.inst, {}):
+                    return self.param.inst_type_table[self.inst][cls](obj)
+                elif cls in self.param.type_table:
+                    return self.param.type_table[cls](self.inst, obj)
+                elif self.param.parent is not None:
+                    try:
+                        return self.param.parent.__get__(
+                            self.inst, self.owner)(obj)
+                    except NotImplementedError:
+                        pass
+            raise NotImplementedError(
+                "Nothing to dispatch to for type {}.".format(type(obj)))
+
+        def register(self, type_, fn):
+            if self.inst not in self.param.inst_type_table:
+                self.param.inst_type_table[self.inst] = (
+                    weakref.WeakKeyDictionary())
+            table = self.param.inst_type_table[self.inst]
+            table[type_] = fn
+            return fn
+
+    def __init__(self, parent=None):
+        self.type_table = weakref.WeakKeyDictionary()
+        self.inst_type_table = weakref.WeakKeyDictionary()
+        self.parent = parent
+
+    def register(self, type_):
+        def _register(fn):
+            assert type_ not in self.type_table
+            self.type_table[type_] = fn
+            return fn
+        return _register
+
+    def __get__(self, inst, owner):
+        if inst is None:
+            return self
+        return self.InstDispatch(self, inst, owner)

--- a/nengo_extras/learning_rules.py
+++ b/nengo_extras/learning_rules.py
@@ -23,7 +23,7 @@ class AML(LearningRuleType):
     ``error[1]`` provides a decay rate (i.e., weights are multiplied with this
     value in every time step), ``error[2:]`` provides the target vector.
 
-    The update is given by:
+    The update is given by::
 
         decoders[...] *= error[1]  # decay
         decoders[...] += alpha * error[0] * error[2:, None] * np.dot(

--- a/nengo_extras/tests/test_gexf.py
+++ b/nengo_extras/tests/test_gexf.py
@@ -1,6 +1,7 @@
+import nengo
 import pytest
 
-from nengo_extras.gexf import DispatchTable
+from nengo_extras.gexf import DispatchTable, HierarchicalLabeler
 
 
 def test_can_dispatch_table_defaults():
@@ -149,3 +150,19 @@ def test_dispatch_errors():
 
     with pytest.raises(NotImplementedError):
         Test().dispatch(object())
+
+
+def test_hierarchical_labeler():
+    with nengo.Network() as model:
+        model.ens = nengo.Ensemble(10, 1)
+        with nengo.Network() as model.subnet:
+            model.subnet.node = nengo.Node(1.)
+            model.subnet.attr = nengo.Ensemble(10, 1)
+
+    labels = HierarchicalLabeler().get_labels(model)
+    assert dict(labels) == {
+        model.ens: 'ens',
+        model.subnet: 'subnet',
+        model.subnet.node: 'subnet.node',
+        model.subnet.attr: 'subnet.attr',
+    }

--- a/nengo_extras/tests/test_gexf.py
+++ b/nengo_extras/tests/test_gexf.py
@@ -1,0 +1,151 @@
+import pytest
+
+from nengo_extras.gexf import DispatchTable
+
+
+def test_can_dispatch_table_defaults():
+    class A(object):
+        def __init__(self):
+            self.called = False
+
+    class Test(object):
+        dispatch = DispatchTable()
+
+        @dispatch.register(A)
+        def process_a(self, obj):
+            obj.called = True
+
+    a = A()
+    Test().dispatch(a)
+    assert a.called
+
+
+def test_dispatch_obj_inheritance():
+    class A(object):
+        def __init__(self):
+            self.called = False
+
+    class B(A):
+        pass
+
+    class C(A):
+        pass
+
+    class Test(object):
+        dispatch = DispatchTable()
+
+        @dispatch.register(A)
+        def process_a(self, obj):
+            obj.called = 'a'
+
+        @dispatch.register(B)
+        def process_b(self, obj):
+            obj.called = 'b'
+
+    a = A()
+    Test().dispatch(a)
+    assert a.called == 'a'
+
+    b = B()
+    Test().dispatch(b)
+    assert b.called == 'b'
+
+    c = C()
+    Test().dispatch(c)
+    assert c.called == 'a'
+
+
+def test_dispatch_cls_inheritance():
+    class A(object):
+        def __init__(self):
+            self.called = False
+
+    class B(object):
+        def __init__(self):
+            self.called = False
+
+    class C(object):
+        def __init__(self):
+            self.called = False
+
+    class Test1(object):
+        dispatch = DispatchTable()
+
+        @dispatch.register(A)
+        def process_a(self, obj):
+            obj.called = 'test1.process_a'
+
+        @dispatch.register(B)
+        def process_b(self, obj):
+            obj.called = 'test1.process_b'
+
+    class Test2(Test1):
+        dispatch = DispatchTable(Test1.dispatch)
+
+        @dispatch.register(B)
+        def process_b(self, obj):
+            obj.called = 'test2.process_b'
+
+        @dispatch.register(C)
+        def process_c(self, obj):
+            obj.called = 'test2.process_c'
+
+    a = A()
+    b = B()
+    Test1().dispatch(a)
+    assert a.called == 'test1.process_a'
+    Test1().dispatch(b)
+    assert b.called == 'test1.process_b'
+
+    a = A()
+    b = B()
+    c = C()
+    Test2().dispatch(a)
+    assert a.called == 'test1.process_a'
+    Test2().dispatch(b)
+    assert b.called == 'test2.process_b'
+    Test2().dispatch(c)
+    assert c.called == 'test2.process_c'
+
+
+def test_dispatch_instance_specific():
+    class A(object):
+        def __init__(self):
+            self.called = False
+
+    class B(object):
+        def __init__(self):
+            self.called = False
+
+    class Test(object):
+        dispatch = DispatchTable()
+
+        @dispatch.register(A)
+        def process_a(self, obj):
+            obj.called = 'test.process_a'
+
+    def proc_inst(obj):
+        obj.called = 'proc_inst'
+
+    test = Test()
+    test2 = Test()
+    test.dispatch.register(A, proc_inst)
+    test.dispatch.register(B, proc_inst)
+
+    a = A()
+    test.dispatch(a)
+    assert a.called == 'proc_inst'
+    test2.dispatch(a)
+    assert a.called == 'test.process_a'
+
+    b = B()
+    test.dispatch(b)
+    assert b.called == 'proc_inst'
+
+
+def test_dispatch_errors():
+    class Test(object):
+        dispatch = DispatchTable()
+
+    with pytest.raises(NotImplementedError):
+        Test().dispatch(object())


### PR DESCRIPTION
(based on PR #56)

This PR adds a conversion of Nengo model to the [GEXF format](https://github.com/gephi/gexf/wiki), which can be opened with [Gephi](https://gephi.org/), a visualization and explanatory analysis software for graphs. The motivation behind this is that Nengo GUI currently is not powerful enough to get a good overview over complex models (e.g., no support to color or temporarily hide objects, no possibility to identify inhibitory or modulatory connections).

A screenshot from a Nengo model visualized in Gephi:
![screenshot_125402](https://user-images.githubusercontent.com/850157/31511567-2b53ab64-af56-11e7-8bba-6fb8b160c497.png)

The main class is `GexfConverter`, doing the basic conversion of a model. But usually there is a bunch of networks (like `spa.State`) where all the detail is too much. `CollapsingGexfConverter` thus extends `GexfConverter` to keep certain networks collapsed. Both classes use the `DispatchTable` descriptor to define conversion methods for different types of Nengo objects. This descriptor allows to overwrite methods in derived classes or on instances to customize the conversion.

Furthermore, there is a `InspectiveLabeler` class to obtain the labels for the graph nodes. This is done by going through the referrers of an object and looking for dictionaries where the key could be used as name and stack frames that contain the object. This might be mildly interesting for Nengo GUI (@tcstewar @tbekolay) as an alternate way to obtain names, but is probably a worse approach. Getting the referrers is a slow operation (because Python has to scan all objects). Also, we cannot get the name for objects that have been created in a function that finished excuting without assigning the object as an attribute. Even worse, those objects get a name like 'o' (depending on the context in which the labeler is executed). Currently, this affects only a few nodes in my model (so I won't spend time on this for now), but might be a limitation for other models.

The GEXF format supports a hierarchical graph representation that can be activated with the `hierarchical=True` flag. However, in the current Gephi version support for hierarchical graphs has been removed (last version with that support is 0.8.x which can still be run with JRE <= 1.7). Thus, it will flatten a hierarchical graph and leave an unconnected node for every network. The default `hierarchical=False` will write a flat graph and avoid those unconnected nodes.