### PR TITLE
Add GEXF documentation

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,11 @@
+.MathJax .mi, .MathJax .mo {
+    color: inherit;
+}
+
+pre, kdb, samp, code, .rst-content tt, .rst-content code {
+    word-break: inherit;
+}
+
+code, .rst-content tt, .rst-content code {
+    white-space: pre-wrap;
+}

--- a/docs/_templates/globaltoc.html
+++ b/docs/_templates/globaltoc.html
@@ -1,0 +1,13 @@
+<div class="sidebar-block">
+  <div class="sidebar-wrapper">
+    <h2>{{ _('Table Of Contents') }}</h2>
+  </div>
+  <div class="sidebar-toc">
+    {% set toctree = toctree(maxdepth=3, collapse=True) %}
+    {% if toctree %}
+      {{ toctree }}
+    {% else %}
+      {{ toc }}
+    {% endif %}
+  </div>
+</div>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,8 @@
+{# Import the theme's layout. #}
+{% extends "!layout.html" %}
+
+{%- block extrahead %}
+<link rel="stylesheet" type="text/css" href="{{ pathto("_static/custom.css", 1) }}">
+{# Call the parent block #}
+{{ super() }}
+{%- endblock %}

--- a/docs/api/nengo_extras.conftest.rst
+++ b/docs/api/nengo_extras.conftest.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.conftest module
+==============================
+
+.. automodule:: nengo_extras.conftest
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.convnet.rst
+++ b/docs/api/nengo_extras.convnet.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.convnet module
+=============================
+
+.. automodule:: nengo_extras.convnet
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.cuda_convnet.rst
+++ b/docs/api/nengo_extras.cuda_convnet.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.cuda\_convnet module
+===================================
+
+.. automodule:: nengo_extras.cuda_convnet
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.data.rst
+++ b/docs/api/nengo_extras.data.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.data module
+==========================
+
+.. automodule:: nengo_extras.data
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.deepnetworks.rst
+++ b/docs/api/nengo_extras.deepnetworks.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.deepnetworks module
+==================================
+
+.. automodule:: nengo_extras.deepnetworks
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.deepview.rst
+++ b/docs/api/nengo_extras.deepview.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.deepview module
+==============================
+
+.. automodule:: nengo_extras.deepview
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.dists.rst
+++ b/docs/api/nengo_extras.dists.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.dists module
+===========================
+
+.. automodule:: nengo_extras.dists
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.graphviz.rst
+++ b/docs/api/nengo_extras.graphviz.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.graphviz module
+==============================
+
+.. automodule:: nengo_extras.graphviz
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.gui.rst
+++ b/docs/api/nengo_extras.gui.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.gui module
+=========================
+
+.. automodule:: nengo_extras.gui
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.keras.rst
+++ b/docs/api/nengo_extras.keras.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.keras module
+===========================
+
+.. automodule:: nengo_extras.keras
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.keras.rst
+++ b/docs/api/nengo_extras.keras.rst
@@ -1,7 +1,3 @@
 nengo\_extras\.keras module
 ===========================
 
-.. automodule:: nengo_extras.keras
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/nengo_extras.learning_rules.rst
+++ b/docs/api/nengo_extras.learning_rules.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.learning\_rules module
+=====================================
+
+.. automodule:: nengo_extras.learning_rules
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.matplotlib.rst
+++ b/docs/api/nengo_extras.matplotlib.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.matplotlib module
+================================
+
+.. automodule:: nengo_extras.matplotlib
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.networks.matrix_multiplication.rst
+++ b/docs/api/nengo_extras.networks.matrix_multiplication.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.networks\.matrix\_multiplication module
+======================================================
+
+.. automodule:: nengo_extras.networks.matrix_multiplication
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.networks.product.rst
+++ b/docs/api/nengo_extras.networks.product.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.networks\.product module
+=======================================
+
+.. automodule:: nengo_extras.networks.product
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.networks.rst
+++ b/docs/api/nengo_extras.networks.rst
@@ -1,0 +1,18 @@
+nengo\_extras\.networks package
+===============================
+
+Submodules
+----------
+
+.. toctree::
+
+   nengo_extras.networks.matrix_multiplication
+   nengo_extras.networks.product
+
+Module contents
+---------------
+
+.. automodule:: nengo_extras.networks
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.neurons.rst
+++ b/docs/api/nengo_extras.neurons.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.neurons module
+=============================
+
+.. automodule:: nengo_extras.neurons
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.plot_spikes.rst
+++ b/docs/api/nengo_extras.plot_spikes.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.plot\_spikes module
+==================================
+
+.. automodule:: nengo_extras.plot_spikes
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.probe.rst
+++ b/docs/api/nengo_extras.probe.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.probe module
+===========================
+
+.. automodule:: nengo_extras.probe
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.rc.rst
+++ b/docs/api/nengo_extras.rc.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.rc module
+========================
+
+.. automodule:: nengo_extras.rc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.rst
+++ b/docs/api/nengo_extras.rst
@@ -1,0 +1,43 @@
+nengo\_extras package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    nengo_extras.networks
+    nengo_extras.spa
+
+Submodules
+----------
+
+.. toctree::
+
+   nengo_extras.conftest
+   nengo_extras.convnet
+   nengo_extras.cuda_convnet
+   nengo_extras.data
+   nengo_extras.deepnetworks
+   nengo_extras.deepview
+   nengo_extras.dists
+   nengo_extras.graphviz
+   nengo_extras.gui
+   nengo_extras.keras
+   nengo_extras.learning_rules
+   nengo_extras.matplotlib
+   nengo_extras.neurons
+   nengo_extras.plot_spikes
+   nengo_extras.probe
+   nengo_extras.rc
+   nengo_extras.utils
+   nengo_extras.version
+   nengo_extras.vision
+
+Module contents
+---------------
+
+.. automodule:: nengo_extras
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.spa.rst
+++ b/docs/api/nengo_extras.spa.rst
@@ -1,0 +1,17 @@
+nengo\_extras\.spa package
+==========================
+
+Submodules
+----------
+
+.. toctree::
+
+   nengo_extras.spa.utils
+
+Module contents
+---------------
+
+.. automodule:: nengo_extras.spa
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.spa.utils.rst
+++ b/docs/api/nengo_extras.spa.utils.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.spa\.utils module
+================================
+
+.. automodule:: nengo_extras.spa.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.utils.rst
+++ b/docs/api/nengo_extras.utils.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.utils module
+===========================
+
+.. automodule:: nengo_extras.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.version.rst
+++ b/docs/api/nengo_extras.version.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.version module
+=============================
+
+.. automodule:: nengo_extras.version
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/nengo_extras.vision.rst
+++ b/docs/api/nengo_extras.vision.rst
@@ -1,0 +1,7 @@
+nengo\_extras\.vision module
+============================
+
+.. automodule:: nengo_extras.vision
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+.. include:: ../CHANGES.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+#
+# This file is execfile()d with the current directory set
+# to its containing dir.
+
+import os
+import os.path
+import shutil
+import sys
+
+try:
+    import nbsphinx
+    import nengo_extras
+    import guzzle_sphinx_theme
+except ImportError:
+    print("To build the documentation, nengo_extras and guzzle_sphinx_theme "
+          "must be installed in the current environment. Please install these "
+          "and their requirements first. A virtualenv is recommended!")
+    sys.exit(1)
+
+
+needs_sphinx = '1.3'
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.todo',
+    'sphinx.ext.viewcode',
+    'guzzle_sphinx_theme',
+    'numpydoc',
+]
+
+# -- sphinx.ext.autodoc
+autoclass_content = 'both'  # class and __init__ docstrings are concatenated
+autodoc_default_flags = ['members']
+autodoc_member_order = 'bysource'  # default is alphabetical
+
+# -- sphinx.ext.intersphinx
+intersphinx_mapping = {
+    'numpy': ('https://docs.scipy.org/doc/numpy', None),
+    'python': ('https://docs.python.org/3/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
+}
+
+# -- sphinx.ext.todo
+todo_include_todos = True
+# -- numpydoc config
+numpydoc_show_class_members = False
+
+# -- sphinx
+exclude_patterns = ['_build']
+source_suffix = ['.rst']
+source_encoding = 'utf-8'
+master_doc = 'index'
+
+
+project = u'Nengo extras'
+authors = u'Applied Brain Research'
+# copyright = nengo_extras.__copyright__
+version = '.'.join(nengo_extras.__version__.split('.')[:2])  # Short X.Y version
+release = nengo_extras.__version__  # Full version, with tags
+pygments_style = 'default'
+
+# -- Options for HTML output --------------------------------------------------
+
+pygments_style = "sphinx"
+templates_path = ["_templates"]
+html_static_path = ["_static"]
+
+html_theme_path = guzzle_sphinx_theme.html_theme_path()
+html_theme = "guzzle_sphinx_theme"
+
+html_theme_options = {
+    "project_nav_name": "Nengo extras %s" % (version,),
+    "base_url": "https://www.nengo.ai/nengo_extras",
+}
+
+html_title = "Nengo core {0} docs".format(release)
+htmlhelp_basename = 'Nengo core'
+html_last_updated_fmt = ''  # Suppress 'Last updated on:' timestamp
+html_show_sphinx = False
+
+# -- Options for LaTeX output -------------------------------------------------
+
+latex_elements = {
+    'papersize': 'letterpaper',
+    'pointsize': '11pt',
+    # 'preamble': '',
+}
+
+latex_documents = [
+    # (source start file, target, title, author, documentclass [howto/manual])
+    ('index', 'nengo_extras.tex', html_title, authors, 'manual'),
+]
+
+# -- Options for manual page output -------------------------------------------
+
+man_pages = [
+    # (source start file, name, description, authors, manual section).
+    ('index', 'nengo_extras', html_title, [authors], 1)
+]
+
+# -- Options for Texinfo output -----------------------------------------------
+
+texinfo_documents = [
+    # (source start file, target, title, author, dir menu entry,
+    #  description, category)
+    ('index', 'nengo_extras', html_title, authors, 'Nengo extras',
+     'Extra utilities and add-ons for Nengo.', 'Miscellaneous'),
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,8 +13,7 @@ try:
     import nengo_extras
     import guzzle_sphinx_theme
 except ImportError:
-    print("To build the documentation, "
-          "nbsphinx, nengo_extras, and guzzle_sphinx_theme "
+    print("To build the documentation, nengo_extras and guzzle_sphinx_theme "
           "must be installed in the current environment. Please install these "
           "and their requirements first. A virtualenv is recommended!")
     sys.exit(1)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,8 @@ try:
     import nengo_extras
     import guzzle_sphinx_theme
 except ImportError:
-    print("To build the documentation, nengo_extras and guzzle_sphinx_theme "
+    print("To build the documentation, "
+          "nbsphinx, nengo_extras, and guzzle_sphinx_theme "
           "must be installed in the current environment. Please install these "
           "and their requirements first. A virtualenv is recommended!")
     sys.exit(1)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,13 +3,9 @@
 # This file is execfile()d with the current directory set
 # to its containing dir.
 
-import os
-import os.path
-import shutil
 import sys
 
 try:
-    import nbsphinx
     import nengo_extras
     import guzzle_sphinx_theme
 except ImportError:
@@ -59,7 +55,8 @@ master_doc = 'index'
 project = u'Nengo extras'
 authors = u'Applied Brain Research'
 # copyright = nengo_extras.__copyright__
-version = '.'.join(nengo_extras.__version__.split('.')[:2])  # Short X.Y version
+version = '.'.join(
+    nengo_extras.__version__.split('.')[:2])  # Short X.Y version
 release = nengo_extras.__version__  # Full version, with tags
 pygments_style = 'default'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,5 +9,12 @@ Full API documentation
 
    api/nengo_extras
 
+Changelog
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   changelog
 
 * :ref:`genindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,13 @@
+.. include::
+   ../README.rst
+
+Full API documentation
+======================
+
+.. toctree::
+   :maxdepth: 2
+
+   api/nengo_extras
+
+
+* :ref:`genindex`

--- a/nengo_extras/deepview.py
+++ b/nengo_extras/deepview.py
@@ -5,7 +5,10 @@ import collections
 
 import numpy as np
 import PIL.ImageTk
-import Tkinter as tk
+try:
+    import tkinter as tk
+except ImportError:
+    import Tkinter as tk
 
 
 class ImageSelector(tk.Frame):

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,5 @@
 sphinx
+nbsphinx
 numpydoc>=0.6
 guzzle_sphinx_theme
 keras

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,4 @@
 sphinx
-nbsphinx
 numpydoc>=0.6
 guzzle_sphinx_theme
 keras

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,6 +1,4 @@
 sphinx
 numpydoc>=0.6
 guzzle_sphinx_theme
-keras
 pillow
-tensorflow

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+sphinx
+numpydoc>=0.6
+guzzle_sphinx_theme
+keras
+pillow
+tensorflow

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[build_sphinx]
+source-dir = docs
+build-dir = docs/_build
+all_files = 1
+
 [check-manifest]
 ignore =
     .travis.yml


### PR DESCRIPTION
It was requested that I add some documentation/tutorial for PR #54. So far there is no proper documentation for this repository and thus not really a place to put that. This PR adds the files required to build the a documentation with `python setup.py build_sphinx` (copied to a large degree from Nengo core). At the moment the documentation just includes the repository readme and contains autogenerated documentation for all of the repository. There is clearly potential to improve that and give it a better structure, but that can be done as separate PRs and I would like to focus on the documentation for my PR instead of going through all the existing stuff in this repository.