### PR TITLE
Remove everything from main namespace

### DIFF
--- a/docs/deeplearning.rst
+++ b/docs/deeplearning.rst
@@ -160,6 +160,6 @@ Networks
 Processes
 =========
 
-.. autoclass:: nengo_extras.Conv2d
+.. autoclass:: nengo_extras.convnet.Conv2d
 
-.. autoclass:: nengo_extras.Pool2d
+.. autoclass:: nengo_extras.convnet.Pool2d

--- a/nengo_extras/__init__.py
+++ b/nengo_extras/__init__.py
@@ -1,11 +1,5 @@
 from .version import version as __version__
 from .rc import rc
 
-# --- nengo_extras namespace (API)
-from .convnet import Conv2d, Pool2d
-from .neurons import FastLIF, SoftLIFRate
-from . import (
-    camera, data, dists, graphviz, gui, networks, neurons, probe, vision)
-
 __copyright__ = "2015-2018, Applied Brain Research"
 __license__ = "Free for non-commercial use; see LICENSE.rst"

--- a/nengo_extras/tests/test_convnet.py
+++ b/nengo_extras/tests/test_convnet.py
@@ -4,7 +4,7 @@ import pytest
 import nengo
 from nengo.utils.stdlib import Timer
 
-from nengo_extras import Conv2d, Pool2d
+from nengo_extras.convnet import Conv2d, Pool2d
 
 
 @pytest.mark.parametrize('local', [False, True])

--- a/nengo_extras/tests/test_keras.py
+++ b/nengo_extras/tests/test_keras.py
@@ -23,7 +23,7 @@ def test_softlif_layer(noise_model, plt):
 
     x = np.linspace(-10, 30, nx)
     y = model.predict(np.ones((ni, 1)) * x)
-    y0 = nengo_extras.SoftLIFRate(**params).rates(x, 1., 1.)
+    y0 = nengo_extras.neurons.SoftLIFRate(**params).rates(x, 1., 1.)
 
     plt.plot(x, y.mean(axis=0), 'b')
     if noise_model != 'none':
@@ -58,7 +58,7 @@ def test_softlif_derivative(noise_model, plt):
 
     x = np.linspace(-10, 30, 1024).reshape(-1, 1)
     dy = df([x])[0]
-    dy0 = nengo_extras.SoftLIFRate(**params).derivative(x, 1., 1.)
+    dy0 = nengo_extras.neurons.SoftLIFRate(**params).derivative(x, 1., 1.)
 
     plt.plot(x, dy)
     plt.plot(x, dy0, 'k--')

--- a/nengo_extras/tests/test_neurons.py
+++ b/nengo_extras/tests/test_neurons.py
@@ -4,8 +4,7 @@ from nengo.utils.numpy import rms
 import numpy as np
 import pytest
 
-from nengo_extras import FastLIF, SoftLIFRate
-from nengo_extras.neurons import rates_isi, rates_kernel
+from nengo_extras.neurons import FastLIF, rates_isi, rates_kernel, SoftLIFRate
 
 
 def test_softlifrate_rates(plt):


### PR DESCRIPTION
Instead, everything should be explicitly imported from its specific submodule.

As suggested in #77. I'll merge and do a 0.3 release once this gets an approved review.