### PR TITLE
Add NumbaLIF neuron model

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -13,7 +13,7 @@ function usage {
 }
 
 if [[ "$COMMAND" == "install" ]]; then
-    conda install --quiet jupyter keras matplotlib "numpy<1.16" pillow scipy tensorflow theano
+    conda install --quiet jupyter keras matplotlib numba "numpy<1.16" pillow scipy tensorflow theano
     pip install coverage "pytest<4.0.0"
     pip install -e .
 elif [[ "$COMMAND" == "run" ]]; then

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,10 @@ Release history
   simulations don't run faster than real time.
   (`#85 <https://github.com/nengo/nengo-extras/pull/85>`_,
    `#151 <https://github.com/nengo/nengo/pull/151>`_)
+- Added ``nengo_extras.neurons.NumbaLIF``, which is a numba-accelerated
+  drop-in replacement for the ``nengo.LIF`` neuron model (requires ``numba`` to
+  be installed).
+  (`#86 <https://github.com/nengo/nengo-extras/pull/86>`_)
 
 0.3.0 (June 4, 2018)
 ====================

--- a/docs/neurons.rst
+++ b/docs/neurons.rst
@@ -13,6 +13,8 @@ can be used.
 
 .. autoclass:: nengo_extras.neurons.FastLIF
 
+.. autoclass:: nengo_extras.neurons.NumbaLIF
+
 Utilities
 =========
 

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,11 @@ testing = "test" in sys.argv or "pytest" in sys.argv
 install_requires = [
     "numpy>=1.8",
     "nengo",
+    "matplotlib>=1.4",
 ]
-plots_require = ["matplotlib>=1.4"]
-deepnetworks_require = [
+optional_require = [
     "keras",
+    "numba>=0.43.1",
     "scipy",
     "theano",
 ]
@@ -47,7 +48,7 @@ docs_require = [
     "pillow",
     "jupyter",
     "matplotlib>=1.4",
-] + deepnetworks_require + plots_require
+]
 tests_require = [
     "jupyter",
     "matplotlib>=1.4",
@@ -71,9 +72,10 @@ setup(
     setup_requires=(["pytest-runner"] if testing else []) + ["numpy>=1.8"],
     install_requires=install_requires,
     extras_require={
-        "deepnetworks": deepnetworks_require,
-        "docs": docs_require,
-        "plots": plots_require,
+        "optional": optional_require,
+        "docs": docs_require + optional_require,
+        "tests": tests_require,
+        "all": optional_require + docs_require + tests_require
     },
     tests_require=tests_require,
     classifiers=[  # https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Migrated from https://github.com/nengo/nengo/pull/1482

I also reworked the `setup.py` `extra_requires` slightly, since I needed to add in `numba` and there wasn't an obvious place to put it.  Could revert this if we want to keep requirements separated by different subcomponents (e.g. one for `deeplearning`, one for `numbalif`). But I figured it'd be ok to lump everything under "optional", and that's familiar for people working with other nengo projects.

Based on https://github.com/nengo/nengo-extras/pull/85, as there are some fixes in that branch needed to get nengo-extras tests passing.