### PR TITLE
Fix imports for Nengo 3.0

### DIFF
--- a/nengo_extras/compat.py
+++ b/nengo_extras/compat.py
@@ -1,14 +1,24 @@
-from nengo.utils.compat import pickle, PY2
+import sys
 
+import nengo
+
+if nengo.version.version_info < (3, 0, 0):
+    from nengo.utils.compat import is_integer, is_iterable
+else:
+    from nengo.utils.numpy import is_integer, is_iterable
+
+PY2 = sys.version_info[0] == 2
 
 if PY2:
     from cStringIO import StringIO
     from urllib import urlretrieve
     import Tkinter as tkinter
+    import cPickle as pickle
 else:
     from io import StringIO
     from urllib.request import urlretrieve
     import tkinter
+    import pickle
 
 
 def cmp(a, b):  # same as python2's builtin cmp, not available in python3

--- a/nengo_extras/conftest.py
+++ b/nengo_extras/conftest.py
@@ -1,1 +1,0 @@
-from nengo.conftest import *  # noqa

--- a/nengo_extras/convnet.py
+++ b/nengo_extras/convnet.py
@@ -2,7 +2,8 @@ import numpy as np
 
 from nengo.processes import Process
 from nengo.params import EnumParam, NdarrayParam, NumberParam, ShapeParam
-from nengo.utils.compat import is_iterable, range
+
+from nengo_extras.compat import is_iterable
 
 
 def softmax(x, axis=None):

--- a/nengo_extras/data.py
+++ b/nengo_extras/data.py
@@ -5,10 +5,9 @@ import re
 import tarfile
 
 import nengo
-from nengo.utils.compat import is_integer, is_iterable
 import numpy as np
 
-from .compat import pickle_load_bytes, urlretrieve
+from .compat import is_integer, is_iterable, pickle_load_bytes, urlretrieve
 
 
 data_dir = nengo.rc.get('nengo_extras', 'data_dir')

--- a/nengo_extras/networks/tests/test_product.py
+++ b/nengo_extras/networks/tests/test_product.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import nengo
-from nengo.utils.compat import range
 from nengo.utils.numpy import rmse
 
 import nengo_extras

--- a/nengo_extras/probe.py
+++ b/nengo_extras/probe.py
@@ -1,5 +1,6 @@
 import nengo
-from nengo.utils.compat import is_iterable
+
+from nengo_extras.compat import is_iterable
 
 
 def probe_all(  # noqa: C901

--- a/nengo_extras/spa/tests/test_utils.py
+++ b/nengo_extras/spa/tests/test_utils.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from nengo.utils.compat import range
 from nengo.utils.numpy import array_hash
 
 from nengo_extras.spa.utils import circconv, cyclic_vector

--- a/nengo_extras/tests/test_neurons.py
+++ b/nengo_extras/tests/test_neurons.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 import timeit
 
 import nengo
@@ -173,7 +174,7 @@ def test_rates_kernel(Simulator, plt, seed):
 
 
 @pytest.mark.noassertions
-def test_rates(Simulator, seed, logger):
+def test_rates(Simulator, seed):
     pytest.importorskip('scipy')
     functions = [
         ('isi_zero', lambda t, s: rates_isi(
@@ -193,8 +194,8 @@ def test_rates(Simulator, seed, logger):
 
     for name, function in functions:
         rel_rmse = _test_rates(Simulator, function, None, seed)
-        logger.info('rate estimator: %s', name)
-        logger.info('relative RMSE: %0.4f', rel_rmse)
+        logging.info("rate estimate: %s", name)
+        logging.info("relative RMSE: %0.4f", rel_rmse)
 
 
 @pytest.mark.slow

--- a/nengo_extras/tests/test_plot_spikes.py
+++ b/nengo_extras/tests/test_plot_spikes.py
@@ -8,14 +8,14 @@ from nengo_extras.plot_spikes import (
 
 
 @pytest.mark.noassertions
-def test_plot_spikes(plt, seed, RefSimulator):
+def test_plot_spikes(plt, seed):
     with nengo.Network(seed=seed) as model:
         ens = nengo.Ensemble(10, 1)
         inp = nengo.Node(np.sin)
         nengo.Connection(inp, ens)
         p = nengo.Probe(ens.neurons, 'spikes')
 
-    with RefSimulator(model) as sim:
+    with nengo.Simulator(model) as sim:
         sim.run(1.)
 
     ax = plt.gca()

--- a/nengo_extras/vision.py
+++ b/nengo_extras/vision.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from nengo.dists import Choice, Uniform, DistributionParam
 from nengo.params import FrozenObject, TupleParam
-from nengo.utils.compat import range
 import nengo.utils.numpy as npext
 
 

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,8 @@ tests_require = [
     "jupyter",
     "matplotlib>=1.4",
     "pytest>=3.2,<4.0.0",
+    "pytest-plt",
+    "pytest-rng",
 ]
 
 


### PR DESCRIPTION
This updates Nengo Extras to be compatible with Nengo 3.0.  Note that there are several tests failing, which I have not attempted to fix. This just allows Nengo Extras to be imported without error, so that the parts that do work can be used.  Since we're not really actively maintaining Nengo Extras (and we may be significantly reworking it in the near future), it didn't seem worthwhile updating a bunch of legacy code at this point.